### PR TITLE
Add CORS_ORIGIN env to README

### DIFF
--- a/README.md
+++ b/README.md
@@ -47,7 +47,12 @@ A comprehensive cybersecurity scanning backend that performs automated security 
 
    # API Keys
    SERPER_KEY=...
+
+   # CORS
+   CORS_ORIGIN=https://your-vercel-domain.vercel.app
    ```
+
+Set `CORS_ORIGIN` to your Vercel domain when the admin app is hosted separately.
 
 3. **Build**:
    ```bash


### PR DESCRIPTION
## Summary
- document `CORS_ORIGIN` in the environment variables
- clarify it should point to the Vercel domain when the admin app is hosted separately

## Testing
- `npm run lint` *(fails: next not found)*

------
https://chatgpt.com/codex/tasks/task_e_6847032b2350832b85358d0e926c0411