### PR TITLE
Fix sed usage on Linux

### DIFF
--- a/scripts/update-imports.sh
+++ b/scripts/update-imports.sh
@@ -4,14 +4,14 @@
 echo "Updating imports in admin app..."
 find apps/admin/src -name "*.tsx" -o -name "*.ts" | while read file; do
   # Update UI component imports
-  sed -i '' "s|from '@/components/ui/\(.*\)'|from '@dealbrief/ui'|g" "$file"
-  sed -i '' "s|from '../components/ui/\(.*\)'|from '@dealbrief/ui'|g" "$file"
-  sed -i '' "s|from '../../components/ui/\(.*\)'|from '@dealbrief/ui'|g" "$file"
+  sed -i.bak "s|from '@/components/ui/\(.*\)'|from '@dealbrief/ui'|g" "$file"
+  sed -i.bak "s|from '../components/ui/\(.*\)'|from '@dealbrief/ui'|g" "$file"
+  sed -i.bak "s|from '../../components/ui/\(.*\)'|from '@dealbrief/ui'|g" "$file"
   
   # Update utils imports
-  sed -i '' "s|from '@/lib/utils'|from '@dealbrief/utils'|g" "$file"
-  sed -i '' "s|from '../lib/utils'|from '@dealbrief/utils'|g" "$file"
-  sed -i '' "s|from '../../lib/utils'|from '@dealbrief/utils'|g" "$file"
+  sed -i.bak "s|from '@/lib/utils'|from '@dealbrief/utils'|g" "$file"
+  sed -i.bak "s|from '../lib/utils'|from '@dealbrief/utils'|g" "$file"
+  sed -i.bak "s|from '../../lib/utils'|from '@dealbrief/utils'|g" "$file"
 done
 
 # Update imports in report-generator app
@@ -23,24 +23,27 @@ find apps/report-generator -name "*.tsx" -o -name "*.ts" | while read file; do
   fi
   
   # Update UI component imports
-  sed -i '' "s|from '@/components/ui/\(.*\)'|from '@dealbrief/ui'|g" "$file"
-  sed -i '' "s|from './components/ui/\(.*\)'|from '@dealbrief/ui'|g" "$file"
-  sed -i '' "s|from '../components/ui/\(.*\)'|from '@dealbrief/ui'|g" "$file"
-  sed -i '' "s|from '../../components/ui/\(.*\)'|from '@dealbrief/ui'|g" "$file"
+  sed -i.bak "s|from '@/components/ui/\(.*\)'|from '@dealbrief/ui'|g" "$file"
+  sed -i.bak "s|from './components/ui/\(.*\)'|from '@dealbrief/ui'|g" "$file"
+  sed -i.bak "s|from '../components/ui/\(.*\)'|from '@dealbrief/ui'|g" "$file"
+  sed -i.bak "s|from '../../components/ui/\(.*\)'|from '@dealbrief/ui'|g" "$file"
   
   # Update utils imports
-  sed -i '' "s|from '@/lib/utils'|from '@dealbrief/utils'|g" "$file"
-  sed -i '' "s|from './lib/utils'|from '@dealbrief/utils'|g" "$file"
-  sed -i '' "s|from '../lib/utils'|from '@dealbrief/utils'|g" "$file"
-  sed -i '' "s|from '../../lib/utils'|from '@dealbrief/utils'|g" "$file"
+  sed -i.bak "s|from '@/lib/utils'|from '@dealbrief/utils'|g" "$file"
+  sed -i.bak "s|from './lib/utils'|from '@dealbrief/utils'|g" "$file"
+  sed -i.bak "s|from '../lib/utils'|from '@dealbrief/utils'|g" "$file"
+  sed -i.bak "s|from '../../lib/utils'|from '@dealbrief/utils'|g" "$file"
   
   # Update hooks imports
-  sed -i '' "s|from '@/hooks/use-mobile'|from '@dealbrief/utils'|g" "$file"
-  sed -i '' "s|from './hooks/use-mobile'|from '@dealbrief/utils'|g" "$file"
-  sed -i '' "s|from '../hooks/use-mobile'|from '@dealbrief/utils'|g" "$file"
-  sed -i '' "s|from '@/hooks/use-toast'|from '@dealbrief/utils'|g" "$file"
-  sed -i '' "s|from './hooks/use-toast'|from '@dealbrief/utils'|g" "$file"
-  sed -i '' "s|from '../hooks/use-toast'|from '@dealbrief/utils'|g" "$file"
+  sed -i.bak "s|from '@/hooks/use-mobile'|from '@dealbrief/utils'|g" "$file"
+  sed -i.bak "s|from './hooks/use-mobile'|from '@dealbrief/utils'|g" "$file"
+  sed -i.bak "s|from '../hooks/use-mobile'|from '@dealbrief/utils'|g" "$file"
+  sed -i.bak "s|from '@/hooks/use-toast'|from '@dealbrief/utils'|g" "$file"
+  sed -i.bak "s|from './hooks/use-toast'|from '@dealbrief/utils'|g" "$file"
+  sed -i.bak "s|from '../hooks/use-toast'|from '@dealbrief/utils'|g" "$file"
 done
 
 echo "Import updates complete!"
+
+# Remove any temporary backup files created by sed
+find apps/admin/src apps/report-generator -name "*.bak" -type f -delete


### PR DESCRIPTION
## Summary
- update `scripts/update-imports.sh` to use `sed -i.bak`
- delete temporary `.bak` files after processing

## Testing
- `npm run lint` *(fails: `next: not found`)*

------
https://chatgpt.com/codex/tasks/task_e_68470310ab24832ba6e66ff23275a4fc