### PR TITLE
docs: use pnpm commands

### DIFF
--- a/Dockerfile.prod
+++ b/Dockerfile.prod
@@ -16,7 +16,7 @@ RUN npm ci
 COPY . .
 
 # Build TypeScript
-RUN npm run build
+RUN pnpm run build
 
 # Production stage
 FROM node:22-alpine

--- a/README.md
+++ b/README.md
@@ -23,9 +23,9 @@ A comprehensive cybersecurity scanning backend that performs automated security 
 
 ## Setup
 
-1. **Install Dependencies**:
+1. **Install Dependencies** (pnpm required for workspace commands):
    ```bash
-   npm install
+   pnpm install
    ```
 
 2. **Environment Variables**:
@@ -51,16 +51,16 @@ A comprehensive cybersecurity scanning backend that performs automated security 
 
 3. **Build**:
    ```bash
-   npm run build
+   pnpm run build
    ```
 
 4. **Run**:
    ```bash
    # API Server
-   npm start
+   pnpm start
 
    # Worker (separate process)
-   npm run worker
+   pnpm run worker
    ```
 
 ## API Endpoints
@@ -142,10 +142,10 @@ docker run -p 8080:8080 dealbrief-scanner
 npm run dev
 
 # Worker development
-npm run worker
+pnpm run worker
 
 # Build TypeScript
-npm run build
+pnpm run build
 ```
 
 ## Security Tools Required

--- a/admin/Dockerfile
+++ b/admin/Dockerfile
@@ -19,7 +19,7 @@ COPY --from=deps /app/node_modules ./node_modules
 COPY . .
 
 # Build the application
-RUN npm run build
+RUN pnpm run build
 
 # Production image, copy all the files and run next
 FROM base AS runner

--- a/admin/README.md
+++ b/admin/README.md
@@ -15,9 +15,9 @@ A comprehensive admin dashboard for managing DealBrief security scans, viewing d
 
 ## Setup
 
-1. **Install dependencies:**
+1. **Install dependencies** (requires pnpm):
    ```bash
-   npm install
+   pnpm install
    ```
 
 2. **Configure environment variables:**

--- a/admin/deploy.sh
+++ b/admin/deploy.sh
@@ -4,7 +4,7 @@ echo "🚀 Deploying DealBrief Admin to Vercel..."
 
 # Build the project first
 echo "📦 Building project..."
-npm run build
+pnpm run build
 
 # Set environment variables in Vercel
 echo "🔧 Setting environment variables..."

--- a/admin/fly.toml
+++ b/admin/fly.toml
@@ -5,7 +5,7 @@ primary_region = 'sea'
 [build]
 
 [processes]
-  app = "npm start"
+  app = "pnpm start"
 
 [http_service]
   internal_port = 3000


### PR DESCRIPTION
## Summary
- update docs and admin config to use `pnpm install`, `pnpm run build`, `pnpm start`, and `pnpm run worker`
- mention that `pnpm` is required

## Testing
- `pnpm run lint` *(fails: next not found)*

------
https://chatgpt.com/codex/tasks/task_e_684702fd590c832b97cf4cd98a492bb3